### PR TITLE
release locks also on exception

### DIFF
--- a/sqlheavy/sqlheavy-query-result.vala
+++ b/sqlheavy/sqlheavy-query-result.vala
@@ -148,10 +148,11 @@ namespace SQLHeavy {
       SQLHeavy.Database db = queryable.database;
 
       this.acquire_locks (queryable, db);
-      var res = this.next_internal ();
-      this.release_locks (queryable, db);
-
-      return res;
+      try {
+        return this.next_internal ();
+      } finally {
+        this.release_locks (queryable, db);
+      }
     }
 
     /**


### PR DESCRIPTION
[PATCH] In QueryResult.next, release locks also on exception.
From https://github.com/nemequ/sqlheavy/issues/27#issuecomment-111759958

Fixes issue #27.