### PR TITLE
GLib.g_object_unref -> GLib.Object.unref

### DIFF
--- a/sqlheavy/sqlheavy-database.vala
+++ b/sqlheavy/sqlheavy-database.vala
@@ -17,7 +17,7 @@ namespace SQLHeavy {
      * List of registered user functions and their respective user data
      */
     private GLib.HashTable <string, UserFunction.UserFuncData> user_functions =
-      new GLib.HashTable <string, UserFunction.UserFuncData>.full (GLib.str_hash, GLib.str_equal, GLib.g_free, GLib.g_object_unref);
+      new GLib.HashTable <string, UserFunction.UserFuncData>.full (GLib.str_hash, GLib.str_equal, GLib.g_free, GLib.Object.unref);
 
     /**
      * List of all SQLHeavy.Table objects, used for change notification
@@ -1011,7 +1011,7 @@ namespace SQLHeavy {
      * @return a hash table of tables, with the key being the table name
      */
     public GLib.HashTable<string, SQLHeavy.Table> get_tables () throws SQLHeavy.Error {
-      var ht = new GLib.HashTable<string, SQLHeavy.Table>.full (GLib.str_hash, GLib.str_equal, GLib.g_free, GLib.g_object_unref);
+      var ht = new GLib.HashTable<string, SQLHeavy.Table>.full (GLib.str_hash, GLib.str_equal, GLib.g_free, GLib.Object.unref);
 
       var result = this.prepare ("SELECT `name` FROM `SQLITE_MASTER` WHERE `type` = 'table';").execute (null);
       while ( !result.finished ) {

--- a/sqlheavy/sqlheavy-user-functions.vala
+++ b/sqlheavy/sqlheavy-user-functions.vala
@@ -137,7 +137,7 @@ namespace SQLHeavy {
             else {
               GLib.Memory.copy (&this._data, this.ctx.aggregate ((int)sizeof (GLib.HashTable)), sizeof (GLib.HashTable));
               if ( this._data == null )
-                this._data = g_hash_table_ref (new GLib.HashTable<string, GLib.Value?>.full (GLib.str_hash, GLib.str_equal, GLib.g_free, GLib.g_object_unref));
+                this._data = g_hash_table_ref (new GLib.HashTable<string, GLib.Value?>.full (GLib.str_hash, GLib.str_equal, GLib.g_free, GLib.Object.unref));
             }
           }
 


### PR DESCRIPTION
It seems that g_object_unref is no longer part of GLib namespace:
https://gitlab.gnome.org/GNOME/vala/-/commit/bcd7a53cdd69befb674f648418cb84777e8ec456#9f621eb5fd3bcb2fa5c7bd228c9b1ad42edc46c8_1_71